### PR TITLE
Add Legends of Future Past

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
 
 * [**Lieve Oma**](https://vltmn.itch.io/lieve-oma), by Florian Veltman.
 * [**Lone Survivor**](http://www.lonesurvivor.co.uk/), by Jasper Byrne.
+* [**Legends of Future Past**](https://github.com/jonradoff/lofp), by Jon Radoff. A 1992 commercial MUD resurrected from original script files using AI. [Play free](https://lofp.metavert.io).
 * [**Lost Soul Aside**](https://www.facebook.com/lostsoulaside/), by Bing Yang.
 * [**Love**](http://www.quelsolaar.com/love/), by Eskil Steenberg.
 * [**Ludus Silva**](http://ludussilva.com/), by Jayelinda Suridge.


### PR DESCRIPTION
Legends of Future Past was a commercial MUD created by Jon Radoff in 1992 that ran until 1999. The engine source code was lost, but the game was solo-reconstructed in 2026 from its original script files using AI. Now open source (MIT) and playable at https://lofp.metavert.io.

- **Wikipedia**: https://en.wikipedia.org/wiki/Legends_of_Future_Past
- Won Computer Gaming World's 1993 Special Award for Artistic Excellence